### PR TITLE
Upgraded dropwizard version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     </distributionManagement>
 
     <properties>
-        <io.dropwizard.version>1.0.0</io.dropwizard.version>
+        <io.dropwizard.version>1.2.0</io.dropwizard.version>
         <getsentry.raven.version>8.0.2</getsentry.raven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/src/main/java/com/tradier/raven/logging/RavenBootstrap.java
+++ b/src/main/java/com/tradier/raven/logging/RavenBootstrap.java
@@ -82,7 +82,7 @@ public final class RavenBootstrap {
       Optional<String> environment, Optional<String> release, Optional<String> serverName,
       boolean cleanRootLogger) {
     final RavenAppenderFactory raven = new RavenAppenderFactory();
-    raven.setThreshold(Level.ERROR);
+    raven.setThreshold(Level.ERROR.levelStr);
     raven.setDsn(dsn);
     raven.setTags(tags);
     raven.setEnvironment(environment);


### PR DESCRIPTION
The current version of dropwizard-raven is not compatible with the dropwizard version 1.2.0. This PR addresses this. Please merge and release a new version. Thanks